### PR TITLE
Rollback when onNewVersion fails

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -442,9 +442,47 @@ func (c *conn) AddDocumentVersion(
 		return err
 	}
 
-	// TODO 1. catch panics from onNewVersion and rollback new document version
-	// TODO 2. rollback new document version on any error from onNewVersion
-	return onNewVersion(ctx, newVersionInfo)
+	safeOnNewVersion := func() (err error) {
+		params := []any{ctx,
+			docID,
+			userID,
+			reason,
+			newVersion,
+		}
+
+		if newVersionInfo != nil {
+			params = append(params, *newVersionInfo)
+		}
+
+		defer errs.RecoverPanicAsErrorWithFuncParams(&err, params...)
+
+		return onNewVersion(ctx, newVersionInfo)
+	}
+
+	err = safeOnNewVersion()
+	if err == nil {
+		return nil
+	}
+
+	_, _, pgCleanupErr := c.metadataStore.DeleteDocumentVersion(ctx, docID, newVersion)
+	if pgCleanupErr != nil {
+		err = errors.Join(err, pgCleanupErr)
+	}
+
+	hashesToDelete := []string{}
+	for _, f := range addedFiles {
+		hashesToDelete = append(hashesToDelete, f.Hash)
+	}
+
+	for _, f := range modifiedFiles {
+		hashesToDelete = append(hashesToDelete, f.Hash)
+	}
+
+	if s3Err := c.documentStore.DeleteDocumentHashes(ctx, docID, hashesToDelete); s3Err != nil {
+		err = errors.Join(err, s3Err)
+	}
+
+	return err
 }
 
 func (c *conn) RestoreDocument(ctx context.Context, doc *HashedDocument, merge bool) error {

--- a/conn.go
+++ b/conn.go
@@ -443,19 +443,7 @@ func (c *conn) AddDocumentVersion(
 	}
 
 	safeOnNewVersion := func() (err error) {
-		params := []any{ctx,
-			docID,
-			userID,
-			reason,
-			newVersion,
-		}
-
-		if newVersionInfo != nil {
-			params = append(params, *newVersionInfo)
-		}
-
-		defer errs.RecoverPanicAsErrorWithFuncParams(&err, params...)
-
+		defer errs.RecoverPanicAsError(&err)
 		return onNewVersion(ctx, newVersionInfo)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/domonda/go-docdb
 go 1.25
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.40.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.91.1
 	github.com/datek/fix v0.2.0
@@ -17,6 +16,7 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.40.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.14 // indirect

--- a/postgres/metadatastore.go
+++ b/postgres/metadatastore.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/ungerik/go-fs"
 
-	"github.com/domonda/go-docdb"
 	"github.com/domonda/go-sqldb/db"
 	"github.com/domonda/go-types/uu"
+
+	"github.com/domonda/go-docdb"
 )
 
 func NewMetadataStore() docdb.MetadataStore {

--- a/postgres/metadatastore_test.go
+++ b/postgres/metadatastore_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/ungerik/go-fs"
 
+	"github.com/domonda/go-sqldb/db"
+	"github.com/domonda/go-types/uu"
+
 	"github.com/domonda/go-docdb"
 	"github.com/domonda/go-docdb/postgres"
 	"github.com/domonda/go-docdb/postgres/pgfixtures"
-	"github.com/domonda/go-sqldb/db"
-	"github.com/domonda/go-types/uu"
 )
 
 var store = postgres.NewMetadataStore()
@@ -601,11 +602,12 @@ func TestDeleteDocumentVersion(t *testing.T) {
 		// given
 		t.Parallel()
 		ctx := pgfixtures.FixtureCtxWithTestTx(t)
+		docID := uu.IDv7()
 
 		// when
-		_, _, err := store.DeleteDocumentVersion(ctx, uu.IDv7(), docdb.VersionTimeFrom(time.Now()))
+		_, _, err := store.DeleteDocumentVersion(ctx, docID, docdb.VersionTimeFrom(time.Now()))
 
 		// then
-		require.ErrorIs(t, err, sql.ErrNoRows)
+		require.ErrorIs(t, err, docdb.NewErrDocumentNotFound(docID))
 	})
 }

--- a/s3/documentstore.go
+++ b/s3/documentstore.go
@@ -12,8 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/ungerik/go-fs"
 
-	"github.com/domonda/go-docdb"
 	"github.com/domonda/go-types/uu"
+
+	"github.com/domonda/go-docdb"
 )
 
 func NewS3DocumentStore(bucketName string, s3Client *awss3.Client) docdb.DocumentStore {


### PR DESCRIPTION
# Purpose

When calling `Conn.AddDocumentVersion()` and the `onNewVersion` function fails, the created objects should be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and recovery for document version creation; automatic rollback ensures data consistency when operations fail.

* **Tests**
  * Added test coverage validating proper rollback and cleanup when document creation encounters errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->